### PR TITLE
Potential fix for code scanning alert no. 3: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/src/gsmmutils/utils/remote.py
+++ b/src/gsmmutils/utils/remote.py
@@ -31,7 +31,8 @@ class Remote:
         """
         try:
             self.client = paramiko.SSHClient()
-            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.client.load_system_host_keys()
+            self.client.set_missing_host_key_policy(paramiko.RejectPolicy())
             host, username, password, container_tool = get_login_info(self.server)
             self.client.connect(host, username=username, password=password)
             self.container_tool = container_tool


### PR DESCRIPTION
Potential fix for [https://github.com/ecunha1996/GSMMutils/security/code-scanning/3](https://github.com/ecunha1996/GSMMutils/security/code-scanning/3)

To fix the issue, replace `paramiko.AutoAddPolicy()` with `paramiko.RejectPolicy()`. This ensures that the application will throw an exception if the host key is unknown, preventing insecure connections. Additionally, the code should be updated to manage known host keys explicitly. This can be done by loading the system's known hosts file or adding specific host keys to the SSH client.

Changes to make:
1. Replace `paramiko.AutoAddPolicy()` with `paramiko.RejectPolicy()`.
2. Load the system's known hosts file using `self.client.load_system_host_keys()` to manage known host keys securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
