### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ on:
     paths-ignore:
       - 'tests/unit_tests/annotation/test_busco.py'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/ecunha1996/GSMMutils/security/code-scanning/1](https://github.com/ecunha1996/GSMMutils/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily checks out code, sets up Python, installs dependencies, and runs tests, it only requires read access to the repository contents. The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` has minimal permissions, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
